### PR TITLE
[Fixes #1] 右下ボタンのスクロールが機能していない

### DIFF
--- a/sightseeing_numazu.html
+++ b/sightseeing_numazu.html
@@ -325,14 +325,13 @@
                // scroll
                scrollOption.click(function () {
                     var href = $(this).attr("href");
-                    var target = $(href == "#" || href == "" ? 'html,body' : href);
+                    var target = $(href == "#" || href == "" ? 'body,html' : href);
                     var position = target.offset().top;
                     $('body,html').animate({
                          scrollTop: position
                     }, 350);
                     return false;
                });
-               //test
           });
      </script>
 

--- a/sightseeing_numazu.html
+++ b/sightseeing_numazu.html
@@ -298,7 +298,7 @@
 
      </div>
 
-     <div id="pageTop" class="scrollOption"><a href="#"></a></div>
+     <div id="pageTop"><a href="#" class="scrollOption"></a></div>
 
      <script src="https://code.jquery.com/jquery-3.6.0.min.js"
           integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>


### PR DESCRIPTION
原因：`target.offset().top`で使用されている変数`target`の指定方法が誤っていた。
子要素->親要素で指定しなければならないところ、
親要素->子要素の順で記載されていたため下記の通り修正。

file: sightseeing_numazu.html
row: 328
```diff
-                    var target = $(href == "#" || href == "" ? 'html,body' : href);
+                    var target = $(href == "#" || href == "" ? 'body,html' : href);
```